### PR TITLE
Update sas_kubectl to handle renamed "APIVERSION" column in `kubectl api-resources` response at v1.20.0

### DIFF
--- a/viya_ark_library/k8s/sas_kubectl.py
+++ b/viya_ark_library/k8s/sas_kubectl.py
@@ -22,6 +22,7 @@ from viya_ark_library.k8s.sas_kubectl_interface import KubectlInterface
 _HEADER_NAME_ = "NAME"
 _HEADER_SHORTNAME_ = "SHORTNAMES"
 _HEADER_APIGROUP_ = "APIGROUP"
+_HEADER_APIVERSION_ = "APIVERSION"
 _HEADER_NAMESPACED_ = "NAMESPACED"
 _HEADER_KIND_ = "KIND"
 _HEADER_VERBS_ = "VERBS"
@@ -140,7 +141,16 @@ class Kubectl(KubectlInterface):
         # get the index of all expected headers #
         name_index: int = api_resource_headers.index(_HEADER_NAME_)
         shortname_index: int = api_resource_headers.index(_HEADER_SHORTNAME_)
-        apigroup_index: int = api_resource_headers.index(_HEADER_APIGROUP_)
+
+        # the "APIGROUP" header is renamed to "APIVERSION" at kubectl v1.20.0
+        # since group describes the values listed at all versions, this method will
+        # return the value as the "api_group"
+        apigroup_index: int = -1
+        if _HEADER_APIGROUP_ in api_resource_headers:
+            apigroup_index = api_resource_headers.index(_HEADER_APIGROUP_)
+        elif _HEADER_APIVERSION_ in api_resource_headers:
+            apigroup_index = api_resource_headers.index(_HEADER_APIVERSION_)
+
         namespaced_index: int = api_resource_headers.index(_HEADER_NAMESPACED_)
         kind_index: int = api_resource_headers.index(_HEADER_KIND_)
         verbs_index: int = api_resource_headers.index(_HEADER_VERBS_)
@@ -176,11 +186,12 @@ class Kubectl(KubectlInterface):
                     break
 
             # get the api group value #
-            for char in api_resource_line[apigroup_index:]:
-                if char != " ":
-                    api_group = api_group + char
-                else:
-                    break
+            if apigroup_index != -1:
+                for char in api_resource_line[apigroup_index:]:
+                    if char != " ":
+                        api_group = api_group + char
+                    else:
+                        break
 
             # get the namespaced value #
             for char in api_resource_line[namespaced_index:]:
@@ -258,7 +269,7 @@ class Kubectl(KubectlInterface):
         # define the command #
         cmd: Text = f" {action} -f {file}"
         # run the command #
-        return (self.do(cmd, ignore_errors))
+        return self.do(cmd, ignore_errors)
 
     def config_view(self, ignore_errors: bool = False) -> Dict:
         # get the raw config response


### PR DESCRIPTION
Pull request for issue #64.