### PR TITLE
(Fix for Issue #80) Issue executing Deployment Report on develop branch using --include-pod-log-snips

### DIFF
--- a/download_pod_logs/model.py
+++ b/download_pod_logs/model.py
@@ -147,7 +147,7 @@ class PodLogDownloader(object):
         error_pods: List[Tuple[Text, Text]] = list()
         for process in write_log_processes:
             try:
-                err_info: List[Tuple[Optional[Text], Text]] = process.get_process().get(timeout=self._wait)
+                err_info: Optional[List[Tuple[Optional[Text], Text]]] = process.get_process().get(timeout=self._wait)
 
                 # add the error message, if returned
                 if err_info:
@@ -159,7 +159,7 @@ class PodLogDownloader(object):
 
     @staticmethod
     def _write_log(kubectl: KubectlInterface, pod: KubernetesResource, tail: int, output_dir: Text,
-                   noparse: bool = False) -> List[Tuple[Optional[Text], Text]]:
+                   noparse: bool = False) -> Optional[List[Tuple[Optional[Text], Text]]]:
         """
         Internal method used for gathering the status and log for each container in the provided pod and writing
         the gathered information to an on-disk log file.
@@ -220,7 +220,7 @@ class PodLogDownloader(object):
                 log: List[AnyStr] = list()
                 try:
                     log = kubectl.logs(pod_name=pod.get_name(), container_name=container_status.get_name(),
-                                       all_containers=False, prefix=False, tail=tail, ignore_errors=False)
+                                       prefix=False, tail=tail, ignore_errors=False)
                 except CalledProcessError as e:
                     # container log has error, we'll retrieve log from initContainers
                     # add log from previous container call
@@ -234,8 +234,8 @@ class PodLogDownloader(object):
                             log += ["\n" + "#" * 50] + [f"# Log from initContainer: {container_name}"] + ["#" * 50]
                             try:
                                 log += kubectl.logs(pod_name=pod.get_name(),
-                                                    container_name=container_name, ignore_errors=True,
-                                                    all_containers=False, prefix=False, tail=tail)
+                                                    container_name=container_name, ignore_errors=True, prefix=False,
+                                                    tail=tail)
 
                             except CalledProcessError:
                                 err_msg = (f"ERROR: A log could not be retrieved for the container "

--- a/download_pod_logs/test/data/expected_usage_output.txt
+++ b/download_pod_logs/test/data/expected_usage_output.txt
@@ -1,7 +1,7 @@
 usage: viya-ark.py download-pod-logs [-h] [-n NAMESPACE] [-o OUTPUT_DIR]
                                      [-p PROCESSES] [-t TAIL] [-w WAIT]
                                      [--no-parse]
-                                     [selected_components [selected_components ...]]
+                                     [selected_components ...]
 
 Download log files for all or a select list of pods.
 

--- a/download_pod_logs/test/data/expected_usage_output.txt
+++ b/download_pod_logs/test/data/expected_usage_output.txt
@@ -1,7 +1,7 @@
 usage: viya-ark.py download-pod-logs [-h] [-n NAMESPACE] [-o OUTPUT_DIR]
                                      [-p PROCESSES] [-t TAIL] [-w WAIT]
                                      [--no-parse]
-                                     [selected_components ...]
+                                     [selected_components [selected_components ...]]
 
 Download log files for all or a select list of pods.
 

--- a/viya_ark_library/k8s/sas_kubectl.py
+++ b/viya_ark_library/k8s/sas_kubectl.py
@@ -312,12 +312,12 @@ class Kubectl(KubectlInterface):
 
         return KubernetesResource(resource_json.decode())
 
-    def logs(self, pod_name: Text, container_name: Text, all_containers: bool = True, prefix: bool = True,
-             tail: int = 10, ignore_errors: bool = False) -> List:
-        # create the command to execute #
+    def logs(self, pod_name: Text, container_name: Optional[Text] = None, prefix: bool = True, tail: int = 10,
+             ignore_errors: bool = False) -> List:
 
+        # create the command to execute #
         cmd: Text
-        if all_containers:
+        if not container_name:
             cmd = f"logs {pod_name} --all-containers --tail={tail}"
         else:
             cmd = f"logs {pod_name} {container_name} --tail={tail}"

--- a/viya_ark_library/k8s/sas_kubectl_interface.py
+++ b/viya_ark_library/k8s/sas_kubectl_interface.py
@@ -186,7 +186,7 @@ class KubectlInterface(ABC):
             $ kubectl logs <pod_name> [--all-containers] [--prefix] --tail=<tail>
 
         :param pod_name: The name of the Pod whose logs should be retrieved.
-        :param container_name: The name of the specific container whose log should be retrieved. If not container is
+        :param container_name: The name of the specific container whose log should be retrieved. If no container is
                                specified, the --all-containers option is used.
         :param prefix: True if the log lines should be prefixed with the container's name, otherwise False.
         :param tail: (default: 10) Limits the results to the given number of lines. Setting this to '-1' will return the

--- a/viya_ark_library/k8s/sas_kubectl_interface.py
+++ b/viya_ark_library/k8s/sas_kubectl_interface.py
@@ -176,7 +176,7 @@ class KubectlInterface(ABC):
         pass
 
     @abstractmethod
-    def logs(self, pod_name: Text, all_containers: bool = True, prefix: bool = True, tail: int = 10,
+    def logs(self, pod_name: Text, container_name: Optional[Text] = None, prefix: bool = True, tail: int = 10,
              ignore_errors: bool = False) -> List:
         """
         Retrieves logs from the pod with the given name.
@@ -186,7 +186,8 @@ class KubectlInterface(ABC):
             $ kubectl logs <pod_name> [--all-containers] [--prefix] --tail=<tail>
 
         :param pod_name: The name of the Pod whose logs should be retrieved.
-        :param all_containers: True if logs should include all containers in the Pod, otherwise False.
+        :param container_name: The name of the specific container whose log should be retrieved. If not container is
+                               specified, the --all-containers option is used.
         :param prefix: True if the log lines should be prefixed with the container's name, otherwise False.
         :param tail: (default: 10) Limits the results to the given number of lines. Setting this to '-1' will return the
                      complete log.

--- a/viya_ark_library/k8s/test_impl/sas_kubectl_test.py
+++ b/viya_ark_library/k8s/test_impl/sas_kubectl_test.py
@@ -419,8 +419,8 @@ class KubectlTest(KubectlInterface):
         # if the resource isn't found by name, raise a CalledProcessError
         raise CalledProcessError(1, f"kubectl get {k8s_api_resource.lower()} {resource_name} -o json")
 
-    def logs(self, pod_name: Text, container_name: Text, all_containers: bool = True, prefix: bool = True,
-             tail: int = 10, ignore_errors: bool = False) -> List:
+    def logs(self, pod_name: Text, container_name: Optional[Text] = None, prefix: bool = True, tail: int = 10,
+             ignore_errors: bool = False) -> List:
         # raise a CalledProcessError if an unexpected namespace is given
         if self.namespace != self.Values.NAMESPACE:
             raise CalledProcessError(1, f"kubectl -n {self.namespace} logs {pod_name}")


### PR DESCRIPTION
In a previous push, the "container_name" parameter was added to the signature for sas_kubectl.logs(). In code review, it was requested that a default be provided for this parameter because the Deployment Report does not use it and would raise an error in execution. That request didn't make it in to the final push, which is causing the Deployment Report error as expected.

Since this parameter has been added, beyond adding the default value, I've refactored to remove the "all_containers" parameter, since this information would be redundant. Now, the logic is:

```
if not container_name:
    # use --all-containers option
else:
    # use container name
```

I also fixed a type hinting error since it did not affect the current functionality.
   