### PR TITLE
(Fix for Issue #81) Download Pod Logs: Error raised when log line is parsed as JSON but is not structured as a dictionary

### DIFF
--- a/viya_ark_library/structured_logging/parser.py
+++ b/viya_ark_library/structured_logging/parser.py
@@ -60,6 +60,12 @@ class SASStructuredLoggingParser(object):
             # in the future, if more logging structures are added, this could be updated to check for more formats
             return log_entry
 
+        # make sure the decoded entry is a dictionary
+        if not isinstance(structured_log_entry, dict):
+            # this is not a dictionary, as expected
+            # return the entry as-is
+            return log_entry
+
         # validate that the structured entry conforms to the spec
         for required_key in SASStructuredLoggingSpec.get_required_keys():
             if required_key not in structured_log_entry:

--- a/viya_ark_library/structured_logging/test/data/expected_log.txt
+++ b/viya_ark_library/structured_logging/test/data/expected_log.txt
@@ -17,3 +17,13 @@ This entry is unstructured and should be returned as-is
 {"level":"info","source":"sas-test","messageKey":"","properties":{"logger":"sas-test","caller":"src/main.go:1"},"timeStamp":"2020-07-29T12:04:17.652950+00:00","message":"This looks like a structured entry but it's missing 'version' (required by spec) so it should be returned as-is"}
 
 {"level":"info","version":1,"source":"sas-test","messageKey":"","properties":{"logger":"sas-test","caller":"src/main.go:1"},"timeStamp":"2020-07-29T12:04:17.652950+00:00"}
+
+# the lines below are valid JSON but will not parse to a dictionary, they should be returned as-is
+
+    1
+
+    true
+
+    false
+
+    ["one", "two", "three"]

--- a/viya_ark_library/structured_logging/test/data/test_log.txt
+++ b/viya_ark_library/structured_logging/test/data/test_log.txt
@@ -17,3 +17,13 @@ This entry is unstructured and should be returned as-is
 {"level":"info","source":"sas-test","messageKey":"","properties":{"logger":"sas-test","caller":"src/main.go:1"},"timeStamp":"2020-07-29T12:04:17.652950+00:00","message":"This looks like a structured entry but it's missing 'version' (required by spec) so it should be returned as-is"}
 
 {"level":"info","version":1,"source":"sas-test","messageKey":"","properties":{"logger":"sas-test","caller":"src/main.go:1"},"timeStamp":"2020-07-29T12:04:17.652950+00:00"}
+
+# the lines below are valid JSON but will not parse to a dictionary, they should be returned as-is
+
+    1
+
+    true
+
+    false
+
+    ["one", "two", "three"]


### PR DESCRIPTION
A check has been added to make sure logs lines parsed as JSON are returned as a Python-native dictionary. The unit test has been updated to check for issues with other values that will parse as valid JSON but will not be returned as a dictionary.