### PR TITLE
(Fix for Issue #85) Deployment Report: Traceback using Kubernetes Server & Client (kubectl) version v1.19+

### DIFF
--- a/deployment_report/model/viya_deployment_report.py
+++ b/deployment_report/model/viya_deployment_report.py
@@ -521,25 +521,6 @@ class ViyaDeploymentReport(object):
         except KeyError:
             return None
 
-    def get_cadence_version(self, resource: KubernetesResource) -> Optional[Text]:
-        """
-        Returns the combined key values from the 'data' dictionary.
-
-        :param key: The key of the value to return.
-        :return: The value mapped to the given key, or None if the given key doesn't exist.
-        """
-        cadence_info: Optional[Text] = None
-        try:
-            if 'sas-deployment-metadata' in resource.get_name():
-                cadence_data = resource.get_data()
-                cadence_info = cadence_data['SAS_CADENCE_NAME'].capitalize() + ' ' + \
-                    cadence_data['SAS_CADENCE_VERSION'] + ' (' + \
-                    cadence_data['SAS_CADENCE_RELEASE'] + ')'
-
-            return cadence_info
-        except KeyError:
-            return None
-
     def write_report(self, output_directory: Text = OUTPUT_DIRECTORY_DEFAULT,
                      data_file_only: bool = DATA_FILE_ONLY_DEFAULT,
                      include_resource_definitions: bool = INCLUDE_RESOURCE_DEFINITIONS_DEFAULT,
@@ -584,3 +565,23 @@ class ViyaDeploymentReport(object):
                                                        include_definitions=include_resource_definitions)
 
         return os.path.abspath(data_file_path), html_file_path
+
+    @staticmethod
+    def get_cadence_version(resource: KubernetesResource) -> Optional[Text]:
+        """
+        Returns the cadence version of the targeted SAS deployment.
+
+        :param resource: The key of the value to return.
+        :return: A string representing the cadence version of the targeted SAS deployment.
+        """
+        cadence_info: Optional[Text] = None
+        try:
+            if 'sas-deployment-metadata' in resource.get_name():
+                cadence_data: Optional[Dict] = resource.get_data()
+                cadence_info = \
+                    (f"{cadence_data['SAS_CADENCE_NAME'].capitalize()} {cadence_data['SAS_CADENCE_VERSION']} "
+                     f"({cadence_data['SAS_CADENCE_RELEASE']})")
+
+            return cadence_info
+        except KeyError:
+            return None

--- a/download_pod_logs/model.py
+++ b/download_pod_logs/model.py
@@ -226,10 +226,10 @@ class PodLogDownloader(object):
 
                     # add anything returned in the raised error
                     if container_err.stdout:
-                        log += str(container_err.stdout).splitlines()
+                        log += str(container_err.stdout.decode()).splitlines()
 
                     if container_err.stderr:
-                        log += str(container_err.stderr).splitlines()
+                        log += str(container_err.stderr.decode()).splitlines()
 
                     initcontainers: Optional[List[Dict]] = pod.get_spec_value(KubernetesResource.Keys.INIT_CONTAINERS)
                     if initcontainers:
@@ -242,10 +242,10 @@ class PodLogDownloader(object):
                             except CalledProcessError as initcontainer_err:
                                 # add anything returned in the raised error
                                 if initcontainer_err.stdout:
-                                    log += str(initcontainer_err.stdout).splitlines()
+                                    log += str(initcontainer_err.stdout.decode()).splitlines()
 
                                 if initcontainer_err.stderr:
-                                    log += str(initcontainer_err.stderr).splitlines()
+                                    log += str(initcontainer_err.stderr.decode()).splitlines()
 
                                 err_msg = (f"ERROR: A log could not be retrieved for the container "
                                            f"[{container_status.get_name()}] "

--- a/viya_ark_library/k8s/sas_kubectl_interface.py
+++ b/viya_ark_library/k8s/sas_kubectl_interface.py
@@ -30,13 +30,15 @@ class KubectlInterface(ABC):
         pass
 
     @abstractmethod
-    def do(self, command: Text, ignore_errors: bool = False) -> AnyStr:
+    def do(self, command: Text, ignore_errors: bool = False, success_rcs: Optional[List[int]] = None) -> AnyStr:
         """
         Generic method for executing a kubectl command.
 
         :param command: The kubectl command to execute.
         :param ignore_errors: True if errors encountered during execution should be ignored (a message will be printed
                               to stdout), otherwise False.
+        :param success_rcs: A list of return codes representing a successful execution of the command. If a None value
+                            is provided, the default list "[0]" will be used.
         :raises CalledProcessError: If the command returns a non-zero return code.
         :return: The stdout of the command that was executed.
         """

--- a/viya_ark_library/k8s/test_impl/sas_kubectl_test.py
+++ b/viya_ark_library/k8s/test_impl/sas_kubectl_test.py
@@ -307,7 +307,7 @@ class KubectlTest(KubectlInterface):
     def get_namespace(self) -> Text:
         return self.namespace
 
-    def do(self, command: Text, ignore_errors: bool = False) -> AnyStr:
+    def do(self, command: Text, ignore_errors: bool = False, success_rcs: Optional[List[int]] = None) -> AnyStr:
         return "Not functional in testing implementation"
 
     def api_resources(self, ignore_errors: bool = False) -> KubernetesApiResources:


### PR DESCRIPTION
Reworked the sas_kubectl.do() method to separate stdout and stderr so that new warning messages in Kubernetes v1.19+ do not cause JSON parsing errors. The "download-pod-logs" command needed a few updates to access the stderr messages as they are now being returned. I also fixed a couple of PEP 8 warnings that don't have an effect on functionality.