### PR TITLE
(Issue #110) Add setup files to make viya4-ark pip installable via Git

### DIFF
--- a/deployment_report/model/viya_deployment_report.py
+++ b/deployment_report/model/viya_deployment_report.py
@@ -62,6 +62,29 @@ class ViyaDeploymentReport(object):
         """
         self._report_data = None
 
+    def as_dict(self) -> Optional[Dict]:
+        """
+        Returns a dictionary representation of the data gathered by this report. All nested objects are maintained
+        as-is. To parse to JSON, the KubernetesObjectJSONEncoder is needed.
+
+        :return: A dictionary representation of the data gathered by this report with all nested objects maintained
+                 as-is, or None if data has not been gathered.
+        """
+        return self._report_data
+
+    def as_dict_json_encoded(self) -> Optional[Dict]:
+        """
+        Returns a dictionary representation of the data gathered by this report. All nested objects are encoded, using
+        the KubernetesObjectJSONEncoder, to native Python objects for JSON compatibility.
+
+        :return: A dictionary representation of the data gathered by this report with all nested objects encoded for
+                 JSON compatibility.
+        """
+        if self._report_data:
+            return json.loads(json.dumps(self._report_data, cls=KubernetesObjectJSONEncoder))
+
+        return None
+
     def gather_details(self, kubectl: KubectlInterface,
                        include_pod_log_snips: bool = INCLUDE_POD_LOG_SNIPS_DEFAULT) -> None:
         """

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+
+####################################################################
+# ### setup.py                                                   ###
+####################################################################
+# ### Author: SAS Institute Inc.                                 ###
+####################################################################
+#                                                                ###
+# Copyright (c) 2021, SAS Institute Inc., Cary, NC, USA.         ###
+# All Rights Reserved.                                           ###
+# SPDX-License-Identifier: Apache-2.0                            ###
+#                                                                ###
+####################################################################
+
+from setuptools import find_packages, setup
+
+# get the install requirements from requirements.txt
+with open("requirements.txt") as requirements_file:
+    install_requirements = requirements_file.read().splitlines()
+
+setup(
+    # UPDATE VERSION WITH EACH RELEASE
+    ##################################
+    version="1.3.1",
+    ##################################
+    name="viya4-ark",
+    author="SAS Institute Inc.",
+    author_email="Josh.Woods@sas.com",
+
+    license="Apache-2.0",
+    licenses_files=["LICENSE"],
+
+    description=("The SAS Viya Administration Resource Kit (SAS Viya ARK) provides tools and utilities to help SAS "
+                 "customers prepare for and gather information about a SAS Viya deployment."),
+    long_description=open("README.md").read(),
+    long_description_content_type="text/markdown",
+
+    url="https://github.com/sassoftware/viya4-ark",
+
+    packages=find_packages(exclude=["tests", "*.tests", "*.tests.*", "tests.*"]),
+
+    python_requires=">=3.6",
+    # these are setup to match the definitions in requirements.txt
+    install_requires=install_requirements
+)


### PR DESCRIPTION
The setup.py file has been added to the project root to allow for pip installation via the "git" protocol. I also added 2 access methods to the ViyaDeploymentReport class it make it easier to use in a pip installation scenario.