### PR TITLE
(Fix for Issue #110) Add setup files to make viya4-ark pip installable via Git

### DIFF
--- a/deployment_report/model/static/viya_deployment_report_keys.py
+++ b/deployment_report/model/static/viya_deployment_report_keys.py
@@ -4,7 +4,7 @@
 # ### Author: SAS Institute Inc.                                 ###
 ####################################################################
 #                                                                ###
-# Copyright (c) 2020, SAS Institute Inc., Cary, NC, USA.         ###
+# Copyright (c) 2021, SAS Institute Inc., Cary, NC, USA.         ###
 # All Rights Reserved.                                           ###
 # SPDX-License-Identifier: Apache-2.0                            ###
 #                                                                ###

--- a/deployment_report/model/test/test_viya_deployment_report.py
+++ b/deployment_report/model/test/test_viya_deployment_report.py
@@ -4,7 +4,7 @@
 # ### Author: SAS Institute Inc.                                 ###
 ####################################################################
 #                                                                ###
-# Copyright (c) 2020, SAS Institute Inc., Cary, NC, USA.         ###
+# Copyright (c) 2021, SAS Institute Inc., Cary, NC, USA.         ###
 # All Rights Reserved.                                           ###
 # SPDX-License-Identifier: Apache-2.0                            ###
 #                                                                ###

--- a/deployment_report/model/utils/test/test_viya_deployment_report_utils.py
+++ b/deployment_report/model/utils/test/test_viya_deployment_report_utils.py
@@ -4,7 +4,7 @@
 # ### Author: SAS Institute Inc.                                 ###
 ####################################################################
 #                                                                ###
-# Copyright (c) 2020, SAS Institute Inc., Cary, NC, USA.         ###
+# Copyright (c) 2021, SAS Institute Inc., Cary, NC, USA.         ###
 # All Rights Reserved.                                           ###
 # SPDX-License-Identifier: Apache-2.0                            ###
 #                                                                ###

--- a/deployment_report/model/utils/viya_deployment_report_utils.py
+++ b/deployment_report/model/utils/viya_deployment_report_utils.py
@@ -4,7 +4,7 @@
 # ### Author: SAS Institute Inc.                                 ###
 ####################################################################
 #                                                                ###
-# Copyright (c) 2020, SAS Institute Inc., Cary, NC, USA.         ###
+# Copyright (c) 2021, SAS Institute Inc., Cary, NC, USA.         ###
 # All Rights Reserved.                                           ###
 # SPDX-License-Identifier: Apache-2.0                            ###
 #                                                                ###

--- a/deployment_report/model/viya_deployment_report.py
+++ b/deployment_report/model/viya_deployment_report.py
@@ -4,7 +4,7 @@
 # ### Author: SAS Institute Inc.                                 ###
 ####################################################################
 #                                                                ###
-# Copyright (c) 2020, SAS Institute Inc., Cary, NC, USA.         ###
+# Copyright (c) 2021, SAS Institute Inc., Cary, NC, USA.         ###
 # All Rights Reserved.                                           ###
 # SPDX-License-Identifier: Apache-2.0                            ###
 #                                                                ###

--- a/deployment_report/model/viya_deployment_report.py
+++ b/deployment_report/model/viya_deployment_report.py
@@ -62,6 +62,29 @@ class ViyaDeploymentReport(object):
         """
         self._report_data = None
 
+    def as_dict(self) -> Optional[Dict]:
+        """
+        Returns a dictionary representation of the data gathered by this report. All nested objects are maintained
+        as-is. To parse to JSON, the KubernetesObjectJSONEncoder is needed.
+
+        :return: A dictionary representation of the data gathered by this report with all nested objects maintained
+                 as-is, or None if data has not been gathered.
+        """
+        return self._report_data
+
+    def as_dict_json_encoded(self) -> Optional[Dict]:
+        """
+        Returns a dictionary representation of the data gathered by this report. All nested objects are encoded, using
+        the KubernetesObjectJSONEncoder, to native Python objects for JSON compatibility.
+
+        :return: A dictionary representation of the data gathered by this report with all nested objects encoded for
+                 JSON compatibility.
+        """
+        if self._report_data:
+            return json.loads(json.dumps(self._report_data, cls=KubernetesObjectJSONEncoder))
+
+        return None
+
     def gather_details(self, kubectl: KubectlInterface,
                        include_pod_log_snips: bool = INCLUDE_POD_LOG_SNIPS_DEFAULT) -> None:
         """

--- a/deployment_report/templates/viya_deployment_report.html.j2
+++ b/deployment_report/templates/viya_deployment_report.html.j2
@@ -3,7 +3,7 @@
 {# ----------------------------------------------------------- #}
 {# Author: SAS Institute Inc.                                  #}
 {# ----------------------------------------------------------- #}
-{# Copyright (c) 2020, SAS Institute Inc., Cary, NC, USA.      #}
+{# Copyright (c) 2021, SAS Institute Inc., Cary, NC, USA.      #}
 {# All Rights Reserved.                                        #}
 {# SPDX-License-Identifier: Apache-2.0                         #}
 {# ----------------------------------------------------------- #}

--- a/download_pod_logs/model.py
+++ b/download_pod_logs/model.py
@@ -4,7 +4,7 @@
 # ### Author: SAS Institute Inc.                                 ###
 ####################################################################
 #                                                                ###
-# Copyright (c) 2020, SAS Institute Inc., Cary, NC, USA.         ###
+# Copyright (c) 2021, SAS Institute Inc., Cary, NC, USA.         ###
 # All Rights Reserved.                                           ###
 # SPDX-License-Identifier: Apache-2.0                            ###
 #                                                                ###

--- a/pre_install_report/library/pre_install_check.py
+++ b/pre_install_report/library/pre_install_check.py
@@ -5,7 +5,7 @@
 # ### Author: SAS Institute Inc.                                 ###
 ####################################################################
 #                                                                ###
-# Copyright (c) 2020, SAS Institute Inc., Cary, NC, USA.         ###
+# Copyright (c) 2021, SAS Institute Inc., Cary, NC, USA.         ###
 # All Rights Reserved.                                           ###
 # SPDX-License-Identifier: Apache-2.0                            ###
 #                                                                ###

--- a/pre_install_report/library/pre_install_check_permissions.py
+++ b/pre_install_report/library/pre_install_check_permissions.py
@@ -5,7 +5,7 @@
 # ### Author: SAS Institute Inc.                                 ###
 ####################################################################
 #                                                                ###
-# Copyright (c) 2020, SAS Institute Inc., Cary, NC, USA.         ###
+# Copyright (c) 2021, SAS Institute Inc., Cary, NC, USA.         ###
 # All Rights Reserved.                                           ###
 # SPDX-License-Identifier: Apache-2.0                            ###
 #                                                                ###

--- a/pre_install_report/library/pre_install_utils.py
+++ b/pre_install_report/library/pre_install_utils.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 ####################################################################
-# ### pre_install_check permissions.py                                 ###
+# ### pre_install_check permissions.py                           ###
 ####################################################################
 # ### Author: SAS Institute Inc.                                 ###
 ####################################################################
 #                                                                ###
-# Copyright (c) 2020, SAS Institute Inc., Cary, NC, USA.         ###
+# Copyright (c) 2021, SAS Institute Inc., Cary, NC, USA.         ###
 # All Rights Reserved.                                           ###
 # SPDX-License-Identifier: Apache-2.0                            ###
 #                                                                ###

--- a/pre_install_report/library/utils/viya_constants.py
+++ b/pre_install_report/library/utils/viya_constants.py
@@ -4,7 +4,7 @@
 # ### Author: SAS Institute Inc.                                 ###
 ####################################################################
 #                                                                ###
-# Copyright (c) 2020, SAS Institute Inc., Cary, NC, USA.         ###
+# Copyright (c) 2021, SAS Institute Inc., Cary, NC, USA.         ###
 # All Rights Reserved.                                           ###
 # SPDX-License-Identifier: Apache-2.0                            ###
 #                                                                ###

--- a/pre_install_report/templates/report_template_viya_pre_install_check.j2
+++ b/pre_install_report/templates/report_template_viya_pre_install_check.j2
@@ -3,7 +3,7 @@
 {# ----------------------------------------------------------- #}
 {# Author: SAS Institute Inc.                                  #}
 {# ----------------------------------------------------------- #}
-{# Copyright (c) 2020, SAS Institute Inc., Cary, NC, USA.      #}
+{# Copyright (c) 2021, SAS Institute Inc., Cary, NC, USA.      #}
 {# All Rights Reserved.                                        #}
 {# SPDX-License-Identifier: Apache-2.0                         #}
 {# ----------------------------------------------------------- #}

--- a/pre_install_report/test/test_pre_install_report.py
+++ b/pre_install_report/test/test_pre_install_report.py
@@ -5,7 +5,7 @@
 # ### Author: SAS Institute Inc.                                 ###
 ####################################################################
 #                                                                ###
-# Copyright (c) 2020, SAS Institute Inc., Cary, NC, USA.         ###
+# Copyright (c) 2021, SAS Institute Inc., Cary, NC, USA.         ###
 # All Rights Reserved.                                           ###
 # SPDX-License-Identifier: Apache-2.0                            ###
 #                                                                ###

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,8 @@
+[metadata]
+name = viya4-ark
+author = SAS Institute Inc.
+summary = The SAS Viya Administration Resource Kit (SAS Viya ARK) provides tools and utilities to help SAS customers prepare for and gather information about a SAS Viya deployment.
+description-file = README.md
+description-content-type = text/markdown
+home-page = https://github.com/sassoftware/viya4-ark
+license = Apache-2.0

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+
+####################################################################
+# ### setup.py                                                   ###
+####################################################################
+# ### Author: SAS Institute Inc.                                 ###
+####################################################################
+#                                                                ###
+# Copyright (c) 2021, SAS Institute Inc., Cary, NC, USA.         ###
+# All Rights Reserved.                                           ###
+# SPDX-License-Identifier: Apache-2.0                            ###
+#                                                                ###
+####################################################################
+
+from setuptools import find_packages, setup
+
+# get the install requirements from requirements.txt
+with open("requirements.txt") as requirements_file:
+    install_requirements = requirements_file.read().splitlines()
+
+setup(
+    name="viya4-ark",
+    author="SAS Institute Inc.",
+
+    license="Apache-2.0",
+    licenses_files=["LICENSE"],
+
+    description=("The SAS Viya Administration Resource Kit (SAS Viya ARK) provides tools and utilities to help SAS "
+                 "customers prepare for and gather information about a SAS Viya deployment."),
+    long_description=open("README.md").read(),
+    long_description_content_type="text/markdown",
+
+    url="https://github.com/sassoftware/viya4-ark",
+
+    packages=find_packages(exclude=["tests", "*.tests", "*.tests.*", "tests.*"]),
+
+    python_requires=">=3.6",
+    # these are setup to match the definitions in requirements.txt
+    install_requires=install_requirements
+)

--- a/setup.py
+++ b/setup.py
@@ -14,27 +14,10 @@
 
 from setuptools import find_packages, setup
 
-# get the install requirements from requirements.txt
-with open("requirements.txt") as requirements_file:
-    install_requirements = requirements_file.read().splitlines()
-
 setup(
-    name="viya4-ark",
-    author="SAS Institute Inc.",
-
-    license="Apache-2.0",
+    setup_requires=["pbr"],
+    pbr=True,
     licenses_files=["LICENSE"],
-
-    description=("The SAS Viya Administration Resource Kit (SAS Viya ARK) provides tools and utilities to help SAS "
-                 "customers prepare for and gather information about a SAS Viya deployment."),
-    long_description=open("README.md").read(),
-    long_description_content_type="text/markdown",
-
-    url="https://github.com/sassoftware/viya4-ark",
-
     packages=find_packages(exclude=["tests", "*.tests", "*.tests.*", "tests.*"]),
-
     python_requires=">=3.6",
-    # these are setup to match the definitions in requirements.txt
-    install_requires=install_requirements
 )

--- a/viya_ark_library/k8s/sas_k8s_objects.py
+++ b/viya_ark_library/k8s/sas_k8s_objects.py
@@ -4,7 +4,7 @@
 # ### Author: SAS Institute Inc.                                 ###
 ####################################################################
 #                                                                ###
-# Copyright (c) 2020, SAS Institute Inc., Cary, NC, USA.         ###
+# Copyright (c) 2021, SAS Institute Inc., Cary, NC, USA.         ###
 # All Rights Reserved.                                           ###
 # SPDX-License-Identifier: Apache-2.0                            ###
 #                                                                ###

--- a/viya_ark_library/k8s/sas_kubectl.py
+++ b/viya_ark_library/k8s/sas_kubectl.py
@@ -4,7 +4,7 @@
 # ### Author: SAS Institute Inc.                                 ###
 ####################################################################
 #                                                                ###
-# Copyright (c) 2020, SAS Institute Inc., Cary, NC, USA.         ###
+# Copyright (c) 2021, SAS Institute Inc., Cary, NC, USA.         ###
 # All Rights Reserved.                                           ###
 # SPDX-License-Identifier: Apache-2.0                            ###
 #                                                                ###

--- a/viya_ark_library/k8s/sas_kubectl_interface.py
+++ b/viya_ark_library/k8s/sas_kubectl_interface.py
@@ -4,7 +4,7 @@
 # ### Author: SAS Institute Inc.                                 ###
 ####################################################################
 #                                                                ###
-# Copyright (c) 2020, SAS Institute Inc., Cary, NC, USA.         ###
+# Copyright (c) 2021, SAS Institute Inc., Cary, NC, USA.         ###
 # All Rights Reserved.                                           ###
 # SPDX-License-Identifier: Apache-2.0                            ###
 #                                                                ###

--- a/viya_ark_library/k8s/test_impl/sas_kubectl_test.py
+++ b/viya_ark_library/k8s/test_impl/sas_kubectl_test.py
@@ -4,7 +4,7 @@
 # ### Author: SAS Institute Inc.                                 ###
 ####################################################################
 #                                                                ###
-# Copyright (c) 2020, SAS Institute Inc., Cary, NC, USA.         ###
+# Copyright (c) 2021, SAS Institute Inc., Cary, NC, USA.         ###
 # All Rights Reserved.                                           ###
 # SPDX-License-Identifier: Apache-2.0                            ###
 #                                                                ###

--- a/viya_ark_library/structured_logging/parser.py
+++ b/viya_ark_library/structured_logging/parser.py
@@ -4,7 +4,7 @@
 # ### Author: SAS Institute Inc.                                 ###
 ####################################################################
 #                                                                ###
-# Copyright (c) 2020, SAS Institute Inc., Cary, NC, USA.         ###
+# Copyright (c) 2021, SAS Institute Inc., Cary, NC, USA.         ###
 # All Rights Reserved.                                           ###
 # SPDX-License-Identifier: Apache-2.0                            ###
 #                                                                ###


### PR DESCRIPTION
- Added setuptools support to allow viya4-ark to be installed via pip using the git protocol
- Added to access methods to the ViyaDeploymentReport class to make it more useful in a pip installation scenario
- Updated the header copyright year on all files modified in 2021