### PR TITLE
Issue 126 Error in the instructions to collect the INGRESS HOST

### DIFF
--- a/pre_install_report/README.md
+++ b/pre_install_report/README.md
@@ -56,7 +56,7 @@ ingress-nginx-controller             LoadBalancer   10.0.00.000   55.147.22.101 
 Use the following commands to determine the parameter values:
 
 ```
-$ export INGRESS_HOST=externalIP=$(kubectl -n <ingress-namespace> get service <nginx-ingress-controller-name> -o jsonpath='{.status.loadBalancer.ingress[*].ip}')
+$ export INGRESS_HOST=$(kubectl -n <ingress-namespace> get service <nginx-ingress-controller-name> -o jsonpath='{.status.loadBalancer.ingress[*].ip}')
 $ export INGRESS_HTTP_PORT=$(kubectl -n <ingress-namespace> get service <nginx-ingress-controller-name> -o jsonpath='{.spec.ports[?(@.name=="http")].port}')
 $ export INGRESS_HTTPS_PORT=$(kubectl -n <ingress-namespace> get service <nginx-ingress-controller-name> -o jsonpath='{.spec.ports[?(@.name=="https")].port}')
 ```


### PR DESCRIPTION
Removed externalIP= from command below:
$ export INGRESS_HOST=$(kubectl -n <ingress-namespace> get service <nginx-ingress-controller-name> -o jsonpath='{.status.loadBalancer.ingress[*].ip}')
