### PR TITLE
(Issue #137) Remove prompt from command usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Each tool that is included in the resource kit provides a readme that describes 
 SAS Viya ARK tools require third-party packages be installed before use. All required packages can be installed using the provided `requirements.txt`:
 
 ```commandline
-$ python3 -m pip install -r requirements.txt
+python3 -m pip install -r requirements.txt
 ```
 The Python packages are only required on the host where SAS Viya ARK tools are executed.   
 

--- a/deployment_report/README.md
+++ b/deployment_report/README.md
@@ -16,7 +16,7 @@ included in the report. Otherwise, un-retrievable information is omitted.
 SAS Viya ARK tools require third-party packages be installed before use. All required packages can be installed using the provided `requirements.txt`:
 
 ```commandline
-$ python3 -m pip install -r requirements.txt
+python3 -m pip install -r requirements.txt
 ```
 
 Download the latest version of this tool and update required packages with every new software order.
@@ -35,7 +35,7 @@ deployment can be specified by including the `-n` or `--namespace` option.
 deployment.
 
 ```commandline
-$ python3 viya-ark.py deployment-report --namespace sas
+python3 viya-ark.py deployment-report --namespace sas
 ```
 
 ### Including Log Snippets for All Pods
@@ -47,7 +47,7 @@ Using this option increases the runtime of the command as well as the size of th
 deployment.
 
 ```commandline
-$ python3 viya-ark.py deployment-report -n sas --include-pod-log-snips
+python3 viya-ark.py deployment-report -n sas --include-pod-log-snips
 ```
 
 ### Including Resource Definitions for All Resources
@@ -59,7 +59,7 @@ definitions for all resources found in the deployment. Using this option increas
 deployment.
 
 ```commandline
-$ python3 viya-ark.py deployment-report -n sas --include-resource-definitions
+python3 viya-ark.py deployment-report -n sas --include-resource-definitions
 ```
 
 ### Creating the Data File Only
@@ -71,7 +71,7 @@ is omitted.
 deployment.
 
 ```commandline
-$ python3 viya-ark.py deployment-report -n sas --data-file-only
+python3 viya-ark.py deployment-report -n sas --data-file-only
 ```
 
 ### Redirecting Output
@@ -84,7 +84,7 @@ any file names.
 deployment.
 
 ```commandline
-$ python3 viya-ark.py deployment-report -n sas --output-dir="/path/to/report/"
+python3 viya-ark.py deployment-report -n sas --output-dir="/path/to/report/"
 ```
 
 ### Help with the Command
@@ -92,7 +92,7 @@ $ python3 viya-ark.py deployment-report -n sas --output-dir="/path/to/report/"
 The `-h` or `--help` option can be used to view usage information and list all options available for the report.
 
 ```commandline
-$ python3 viya-ark.py deployment-report --help
+python3 viya-ark.py deployment-report --help
 ```
 
 ## Report Output

--- a/download_pod_logs/README.md
+++ b/download_pod_logs/README.md
@@ -14,7 +14,7 @@ information available for the pod container when the tool is executed.
 SAS Viya ARK tools require that third-party packages be installed before use. You can install all the required packages by using the provided requirements.txt file in the following command:
 
 ```commandline
-$ python3 -m pip install -r requirements.txt
+python3 -m pip install -r requirements.txt
 ```
 
 Download the latest version of this tool and update the required packages with every new software order.
@@ -33,7 +33,7 @@ Viya deployment should be specified by including the `-n` or `--namespace` optio
 deployment.
 
 ```commandline
-$ python3 viya-ark.py download-pod-logs --namespace sas
+python3 viya-ark.py download-pod-logs --namespace sas
 ```
 
 ### Controlling Log Size
@@ -45,7 +45,7 @@ The following example limits the returned log lines to 1000.
 deployment.
 
 ```commandline
-$ python3 viya-ark.py download-pod-logs --namespace sas --tail 1000
+python3 viya-ark.py download-pod-logs --namespace sas --tail 1000
 ```
 
 ### Selecting SAS Component Pods
@@ -60,7 +60,7 @@ The following example returns logs from the sas-visual-analytics-app and sas-con
 deployment.
 
 ```commandline
-$ python3 viya-ark.py download-pod-logs --namespace sas --tail 100 sas-visual-analytics-app sas-consul-server
+python3 viya-ark.py download-pod-logs --namespace sas --tail 100 sas-visual-analytics-app sas-consul-server
 ```
 
 ### Redirecting Output
@@ -73,7 +73,7 @@ timestamped directory inside of the `output-dir` location to allow for multiple 
 deployment.
 
 ```commandline
-$ python3 viya-ark.py download-pod-logs -n sas --output-dir="/path/to/report/"
+python3 viya-ark.py download-pod-logs -n sas --output-dir="/path/to/report/"
 ```
 
 ### Help with the Command
@@ -81,5 +81,5 @@ $ python3 viya-ark.py download-pod-logs -n sas --output-dir="/path/to/report/"
 The `-h` or `--help` option can be used to view usage information and list all options available for this tool.
 
 ```commandline
-$ python3 viya-ark.py download-pod-logs --help
+python3 viya-ark.py download-pod-logs --help
 ```

--- a/ldap_validator/README.md
+++ b/ldap_validator/README.md
@@ -27,7 +27,7 @@ SAS Viya ARK tools require third-party packages be installed before use. All req
 provided `requirements.txt`:
 
 ```commandline
-$ python3 -m pip install -r requirements.txt
+python3 -m pip install -r requirements.txt
 ```
 
 Download the latest version of this tool and update required packages with every new software order.
@@ -37,12 +37,12 @@ Download the latest version of this tool and update required packages with every
 The following command provides usage details:
 
 ```
-$ python3 viya-ark.py ldap_validator --help
+python3 viya-ark.py ldap_validator --help
 ```
 The following example executes the LDAP Validation script against the specified sitedefault.yaml. 
 
 ```commandline
-$ python3 viya-ark.py ldap_validator -s /path/to/sitedefault.yaml
+python3 viya-ark.py ldap_validator -s /path/to/sitedefault.yaml
 ```
 
 ## Log Output

--- a/pre_install_report/README.md
+++ b/pre_install_report/README.md
@@ -12,7 +12,7 @@ SAS recommends running the tool and resolving any reported issues before beginni
 SAS Viya ARK tools require third-party packages be installed before use. You can install all the required packages by using the provided requirements.txt file in the following command:
 
 ```commandline
-$ python3 -m pip install -r requirements.txt
+python3 -m pip install -r requirements.txt
 ```
 
 Download the latest version of this tool and update required packages with every new software order.


### PR DESCRIPTION
Simplifies copy/paste of commands.  GitHub 'clipboard' button picks up command prompt and makes pasting the command cumbersome (requiring edit of the pasted string).