### PR TITLE
issue 147: Validate data in viya_deployment_settings.ini

### DIFF
--- a/pre_install_report/library/pre_install_check.py
+++ b/pre_install_report/library/pre_install_check.py
@@ -571,6 +571,7 @@ class ViyaPreInstallCheck():
                          (str(viya_constants.VIYA_PERCENTAGE_OF_INSTANCE),
                           str(min_aggr_worker_memory * (int(viya_constants.VIYA_PERCENTAGE_OF_INSTANCE) / 100)),
                           str(total_capacity_memory_toGB)))
+        self.logger.info("input memory converted to G {}".format(str(min_aggr_worker_memory.to('G'))))
         if total_capacity_memory_toGB < \
                 (min_aggr_worker_memory.to('G')) * (int(viya_constants.VIYA_PERCENTAGE_OF_INSTANCE) / 100):
 
@@ -907,19 +908,20 @@ class ViyaPreInstallCheck():
 
         try:
             current = tuple(kubeletversion.split("."))
-        except ValueError:
-            return False
-        self.logger.info("current: " + pprint.pformat(current)
-                         + ", min: " + pprint.pformat(self._min_kubelet_version))
 
-        if int(current[0][1:]) > int(self._min_kubelet_version[0][1:]):
-            return True
-        if int(current[0][1:]) < int(self._min_kubelet_version[0][1:]):
+            if int(current[0][1:]) > int(self._min_kubelet_version[0][1:]):
+                return True
+            if int(current[0][1:]) < int(self._min_kubelet_version[0][1:]):
+                return False
+            if int(current[0][1:]) == int(self._min_kubelet_version[0][1:]) and \
+                    (int(current[1]) >= int(self._min_kubelet_version[1])):
+                return True
             return False
-        if int(current[0][1:]) == int(self._min_kubelet_version[0][1:]) and \
-                (int(current[1]) >= int(self._min_kubelet_version[1])):
-            return True
-        return False
+        except ValueError:
+            print(viya_messages.LIMIT_ERROR.format("VIYA_KUBELET_VERSION_MIN", str(self._min_kubelet_version)))
+            self.logger.exception(viya_messages.LIMIT_ERROR.format("VIYA_KUBELET_VERSION_MIN", str(self._min_kubelet_version)))
+            sys.exit(viya_messages.BAD_OPT_RC_)
+
 
     def _get_memory(self, limit, key, quantity_):
         """
@@ -953,9 +955,9 @@ class ViyaPreInstallCheck():
             input_cpu = float(limit)
             return input_cpu
         except ValueError:
-            print(viya_messages.CPU_ERROR.format(key,
+            print(viya_messages.LIMIT_ERROR.format(key,
                                                  str(limit)))
-            self.logger.exception(viya_messages.CPU_ERROR.format(key, str(limit)))
+            self.logger.exception(viya_messages.LIMIT_ERROR.format(key, str(limit)))
             sys.exit(viya_messages.BAD_OPT_RC_)
 
     def get_config_info(self):

--- a/pre_install_report/library/pre_install_check.py
+++ b/pre_install_report/library/pre_install_check.py
@@ -919,9 +919,9 @@ class ViyaPreInstallCheck():
             return False
         except ValueError:
             print(viya_messages.LIMIT_ERROR.format("VIYA_KUBELET_VERSION_MIN", str(self._min_kubelet_version)))
-            self.logger.exception(viya_messages.LIMIT_ERROR.format("VIYA_KUBELET_VERSION_MIN", str(self._min_kubelet_version)))
+            self.logger.exception(viya_messages.LIMIT_ERROR.format("VIYA_KUBELET_VERSION_MIN",
+                                                                   str(self._min_kubelet_version)))
             sys.exit(viya_messages.BAD_OPT_RC_)
-
 
     def _get_memory(self, limit, key, quantity_):
         """
@@ -955,8 +955,7 @@ class ViyaPreInstallCheck():
             input_cpu = float(limit)
             return input_cpu
         except ValueError:
-            print(viya_messages.LIMIT_ERROR.format(key,
-                                                 str(limit)))
+            print(viya_messages.LIMIT_ERROR.format(key, str(limit)))
             self.logger.exception(viya_messages.LIMIT_ERROR.format(key, str(limit)))
             sys.exit(viya_messages.BAD_OPT_RC_)
 

--- a/pre_install_report/library/utils/viya_messages.py
+++ b/pre_install_report/library/utils/viya_messages.py
@@ -21,7 +21,7 @@ KUBECONF_ERROR = "ERROR: KUBECONFIG environment var must be set for the script "
 CHECK_NAMESPACE = ' ERROR: Check available permissions in namespace and if it is valid: '
 LIMIT_ERROR = 'ERROR: The value in the viya_deployment_settings.ini file is not valid: {} = {}'
 KUBELET_VERSION_ERROR = 'ERROR: Check the VIYA_KUBELET_VERSION_MIN value ' \
-                        'specified in the <tool-download-dir>/viya4-ark/pre_install_report/viya_deployment_settings.ini file'
+                        'specified in the pre_install_report/viya_deployment_settings.ini file'
 OPTION_ERROR = "ERROR: option {} not recognized"
 OPTION_VALUES_ERROR = "ERROR: Provide valid values for all required options. Check options -i, -p and -H."
 INGRESS_CONTROLLER_ERROR = "ERROR: Ingress controller specified must be nginx. Check value on option -i "

--- a/pre_install_report/library/utils/viya_messages.py
+++ b/pre_install_report/library/utils/viya_messages.py
@@ -19,9 +19,9 @@ CONFIG_ERROR = "ERROR: Unable to read configuration file. Make " \
 KUBECONF_ERROR = "ERROR: KUBECONFIG environment var must be set for the script " \
                 "to access the Kubernetes cluster."
 CHECK_NAMESPACE = ' ERROR: Check available permissions in namespace and if it is valid: '
-LIMIT_ERROR = 'ERROR: The value in the viya_set_limits.py file is not valid: {} = {}'
-KUBELET_VERSION_ERROR = 'ERROR: Check the VIYA_KUBELET_VERSION_MIN and VIYA_KUBELET_VERSION_MAX values ' \
-                        'specified in the <tool-download-dir>/viya4-ark/pre_install_report/viya_set_limit.py file'
+LIMIT_ERROR = 'ERROR: The value in the viya_deployment_settings.ini file is not valid: {} = {}'
+KUBELET_VERSION_ERROR = 'ERROR: Check the VIYA_KUBELET_VERSION_MIN value ' \
+                        'specified in the <tool-download-dir>/viya4-ark/pre_install_report/viya_deployment_settings.ini file'
 OPTION_ERROR = "ERROR: option {} not recognized"
 OPTION_VALUES_ERROR = "ERROR: Provide valid values for all required options. Check options -i, -p and -H."
 INGRESS_CONTROLLER_ERROR = "ERROR: Ingress controller specified must be nginx. Check value on option -i "

--- a/pre_install_report/viya_deployment_settings.ini
+++ b/pre_install_report/viya_deployment_settings.ini
@@ -24,11 +24,12 @@
 #
 [items]
 # TOTAL Memory of all worker Nodes in GB. Sum of the Memory on all active node required to deploy a specific offering.
+# Append G after the value
 VIYA_MIN_AGGREGATE_WORKER_MEMORY=448G
 # TOTAL CPU of all worker Nodes in millicores. Sum of the vCPUs on all active node required to deploy a specific offering
 # Minimum allowed value = '.001'.
 VIYA_MIN_AGGREGATE_WORKER_CPU_CORES=56
 # Supported versions of Kubelet Version
-# Expected: xx if used for Viya Deployment
+# Expected format: vxx.xx.0
 VIYA_KUBELET_VERSION_MIN=v1.19.0
 

--- a/pre_install_report/viya_deployment_settings.ini
+++ b/pre_install_report/viya_deployment_settings.ini
@@ -26,10 +26,9 @@
 # TOTAL Memory of all worker Nodes in GB. Sum of the Memory on all active node required to deploy a specific offering.
 # Must append G after the value
 VIYA_MIN_AGGREGATE_WORKER_MEMORY=448G
-# TOTAL CPU of all worker Nodes in millicores. Sum of the vCPUs on all active node required to deploy a specific offering
+# TOTAL CPU of all worker Nodes in millicores. Sum of the vCPUs on all active nodes required to deploy an offering
 # Minimum allowed value = '.001'.
 VIYA_MIN_AGGREGATE_WORKER_CPU_CORES=56
 # Supported versions of Kubelet Version
 # Expected format: vxx.xx.0
 VIYA_KUBELET_VERSION_MIN=v1.19.0
-

--- a/pre_install_report/viya_deployment_settings.ini
+++ b/pre_install_report/viya_deployment_settings.ini
@@ -24,7 +24,7 @@
 #
 [items]
 # TOTAL Memory of all worker Nodes in GB. Sum of the Memory on all active node required to deploy a specific offering.
-# Append G after the value
+# Must append G after the value
 VIYA_MIN_AGGREGATE_WORKER_MEMORY=448G
 # TOTAL CPU of all worker Nodes in millicores. Sum of the vCPUs on all active node required to deploy a specific offering
 # Minimum allowed value = '.001'.


### PR DESCRIPTION
Validate the value specified for the following keys in the pre_install_report/viya_deployment_settings.ini file:
VIYA_MIN_AGGREGATE_WORKER_MEMORY=448G
VIYA_MIN_AGGREGATE_WORKER_CPU_CORES=56
VIYA_KUBELET_VERSION_MIN=v1.19.0