### PR TITLE
Update flake8 usage

### DIFF
--- a/.github/workflows/ci-validation.yml
+++ b/.github/workflows/ci-validation.yml
@@ -23,11 +23,13 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install flake8 pytest
+        flake8 --version
+        pytest --version
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --max-line-length 120 --show-source --statistics
+        flake8 . --count --max-line-length 120 --show-source --statistics --extend-ignore=E275
     - name: Test with pytest
       run: |
         pytest


### PR DESCRIPTION
Output flake8 and pytest versions after installation Add --extend-ignore=E275 to ignore rule for adding whitespace after keywords.  Appears to have been introduced as a default with flake8 5.x