### PR TITLE
feat: update VIYA_K8S_VERSION_MIN to 1.26

### DIFF
--- a/pre_install_report/viya_deployment_settings.ini
+++ b/pre_install_report/viya_deployment_settings.ini
@@ -4,7 +4,7 @@
 # ### Author: SAS Institute Inc.                                  ###
 # ###################################################################
 #                                                                 ###
-# Copyright (c) 2021-2023, SAS Institute Inc., Cary, NC, USA.     ###
+# Copyright (c) 2021-2024, SAS Institute Inc., Cary, NC, USA.     ###
 # All Rights Reserved.                                            ###
 # SPDX-License-Identifier: Apache-2.0                             ###
 #                                                                 ###
@@ -30,4 +30,4 @@ VIYA_MIN_AGGREGATE_WORKER_MEMORY=448G
 # Minimum allowed value = '.001'.
 VIYA_MIN_AGGREGATE_WORKER_CPU_CORES=56
 # Minimum Kubernetes Server Version supported.  Format: major.minor
-VIYA_K8S_VERSION_MIN=1.24
+VIYA_K8S_VERSION_MIN=1.26


### PR DESCRIPTION
The change is needed based on the progression of SAS Viya Platform's Kubernetes minimum support levels.