### PR TITLE
fix: allow running the script without KUBECONFIG

### DIFF
--- a/pre_install_report/library/pre_install_check.py
+++ b/pre_install_report/library/pre_install_check.py
@@ -218,21 +218,6 @@ class ViyaPreInstallCheck():
                              output_dir)
         return
 
-    def _read_environment_var(self, env_var):
-        """
-        This method verifies that the KUBECONFIG environment variable is set.
-
-        :param env_var: Environment variable to check
-        """
-        try:
-            value_env_var = os.environ[env_var]
-        except Exception:
-            self.logger.exception("CalledProcessorError")
-            print(viya_messages.KUBECONF_ERROR)
-            sys.exit(viya_messages.BAD_ENV_RC_)
-
-        return value_env_var
-
     def _get_nested_info(self, nested_nodes, extracted_nodes, search_key):
 
         try:

--- a/pre_install_report/library/utils/viya_messages.py
+++ b/pre_install_report/library/utils/viya_messages.py
@@ -16,8 +16,6 @@ CONFIG_ERROR = "ERROR: Unable to read configuration file. Make " \
                "sure that kubectl" \
                " is properly configured and the KUBECONFIG " \
                "environment variable has a valid value"
-KUBECONF_ERROR = "ERROR: KUBECONFIG environment var must be set for the script " \
-                "to access the Kubernetes cluster."
 CHECK_NAMESPACE = ' ERROR: Check available permissions in namespace and if it is valid: '
 LIMIT_ERROR = 'ERROR: The value in the viya_deployment_settings.ini file is not valid: {} = {}'
 KUBELET_VERSION_ERROR = 'ERROR: Check the VIYA_K8S_VERSION_MIN value ' \

--- a/pre_install_report/pre_install_report.py
+++ b/pre_install_report/pre_install_report.py
@@ -74,24 +74,6 @@ def _read_config_file(filename):
             sys.exit(viya_messages.SET_LIMTS_ERROR_RC_)
 
 
-def read_environment_var(env_var):
-    """
-    This method verifies that the KUBECONFIG environment variable is set.
-
-    :param env_var: Environment variable to check
-    """
-    try:
-        value_env_var = os.environ[env_var]
-        # Check if specified file exists
-        if not os.path.exists(value_env_var):
-            print(viya_messages.KUBECONF_FILE_ERROR.format(value_env_var))
-            sys.exit(viya_messages.BAD_ENV_RC_)
-    except Exception:
-        print(viya_messages.KUBECONF_ERROR)
-        sys.exit(viya_messages.BAD_ENV_RC_)
-    return value_env_var
-
-
 class PreInstallReportCommand(Command):
     """
     Command implementation for the pre-install command to register
@@ -198,7 +180,6 @@ def main(argv):
 
     sas_logger = ViyaARKLogger(report_log_path, logging_level=logging_level, logger_name="pre_install_logger")
     logger = sas_logger.get_logger()
-    read_environment_var('KUBECONFIG')
 
     try:
         kubectl = Kubectl(namespace=name_space)

--- a/pre_install_report/test/test_pre_install_report.py
+++ b/pre_install_report/test/test_pre_install_report.py
@@ -25,7 +25,6 @@ from pre_install_report.library.pre_install_check import ViyaPreInstallCheck
 from pre_install_report.library.pre_install_check_permissions import PreCheckPermissions
 from viya_ark_library.jinja2.sas_jinja2 import Jinja2TemplateRenderer
 from viya_ark_library.logging import ViyaARKLogger
-from pre_install_report.pre_install_report import read_environment_var
 from pre_install_report.library.utils import viya_messages
 
 _SUCCESS_RC_ = 0
@@ -546,20 +545,6 @@ def test_get_calculated_aggregate_memory():
 
     total_calc_memoryGi = vpc.get_calculated_aggregate_memory()
     assert str(round(total_calc_memoryGi.to('Gi'), 13)) == '62.5229606628418 Gi'
-
-
-def test_kubconfig_file():
-    old_kubeconfig = os.environ.get('KUBECONFIG')  # /Users/cat/doc
-    os.environ['KUBECONFIG'] = 'blah_nonexistentfile_blah'
-    new_kubeconfig = os.environ.get('KUBECONFIG')  # /Users/cat/doc
-    assert new_kubeconfig == 'blah_nonexistentfile_blah'
-    try:
-        read_environment_var('KUBECONFIG')
-    except SystemExit as exc:
-        assert exc.code == viya_messages.BAD_ENV_RC_
-        pass
-    finally:
-        os.environ['KUBECONFIG'] = str(old_kubeconfig)
 
 
 def test_validated_k8s_server_version():


### PR DESCRIPTION
`kubectl` uses `~/.kube/config` by default. Forcing the user to redefine the variable is unnecessary in this case.

If `KUBECONFIG` needs to be set because the default path does not exist, we raise the error in `viya_ark_library/k8s/sas_kubectl.py:69` anyway.

`viya_messages.BAD_ENV_RC_` could also be removed, but I left it in for backwards compatibility. I can update the PR if needed :)