### PR TITLE
docs: add ingress namespace deployment report option (VIYAARKCD-317)

### DIFF
--- a/deployment_report/README.md
+++ b/deployment_report/README.md
@@ -37,6 +37,13 @@ deployment can be specified by including the `-n` or `--namespace` option.
 python3 viya-ark.py deployment-report --namespace sas
 ```
 
+### Specifying Ingress Controller Namespace
+
+The `-i` or `--ingress-namespace` option MUST be used to specified the namespace where the ingress controller is deployed.
+
+```commandline
+python3 viya-ark.py deployment-report --namespace sas --ingress-namespace ingress-ns
+```
 ### Including Log Snippets for All Pods
 
 Including the `-l` or `--include-pod-log-snips` option yields a report with a 10-line log snippet for each pod.

--- a/deployment_report/README.md
+++ b/deployment_report/README.md
@@ -39,7 +39,7 @@ python3 viya-ark.py deployment-report --namespace sas
 
 ### Specifying Ingress Controller Namespace
 
-The `-i` or `--ingress-namespace` option MUST be used to specified the namespace where the ingress controller is deployed.
+The `-i` or `--ingress-namespace` option MUST be used to specify the namespace where the ingress controller is deployed.
 
 ```commandline
 python3 viya-ark.py deployment-report --namespace sas --ingress-namespace ingress-ns

--- a/deployment_report/README.md
+++ b/deployment_report/README.md
@@ -39,11 +39,13 @@ python3 viya-ark.py deployment-report --namespace sas
 
 ### Specifying Ingress Controller Namespace
 
-The `-i` or `--ingress-namespace` option MUST be used to specify the namespace where the ingress controller is deployed.
+The `-i` or `--ingress-namespace` option can be used to specify the namespace where the ingress controller is deployed.
 
 ```commandline
 python3 viya-ark.py deployment-report --namespace sas --ingress-namespace ingress-ns
 ```
+**Note**: This option can be helpful if there are issues detecting the correct ingress controller automatically.
+
 ### Including Log Snippets for All Pods
 
 Including the `-l` or `--include-pod-log-snips` option yields a report with a 10-line log snippet for each pod.


### PR DESCRIPTION
This `deployment-report` documentation change addresses a workaround for issue #209. The issue can generally be avoided by specifying the correct namespace where the ingress controller is deployed.