### PR TITLE
fix: generalized pod name label search for contour ingress (VIYAARKCD-319)

### DIFF
--- a/deployment_report/model/utils/ingress_util.py
+++ b/deployment_report/model/utils/ingress_util.py
@@ -173,7 +173,7 @@ def get_ingress_version(kubectl: KubectlInterface, ingress_controller: Text) -> 
 
     elif ingress_controller == SupportedIngress.Controllers.CONTOUR:
         podname: AnyStr = kubectl.do(getpod_cmd +
-                                     " -l app=envoy")
+                                     " -l controller-revision-hash")
         if podname:
             version_str: AnyStr = kubectl.do("get pod " + podname.decode() +
                                              " -n " + kubectl.ingress_ns +


### PR DESCRIPTION
This change will prevent exceptions that have been observed when operating with ingress controllers other than NGINX. In particular, this change is focused on Contour ingress controller and the common label available in pod metadata required to distinguish the controller for further interrogation.  There is a disparity between cloud provider based clusters and opensource clusters in the original label used for Contour.  This change establishes a common label for use. 